### PR TITLE
question about gaussian_kern() parameters?

### DIFF
--- a/vardpoor/R/linarpr.R
+++ b/vardpoor/R/linarpr.R
@@ -261,7 +261,7 @@ arprlinCalc <- function(Y1, ids, wght1, indicator,
     h <- bandwith_plug(y = Y1, w = wt)
 
     f_quant2 <- gaussian_kern(inco = Y1, wt = wt,
-                              quant_val = quant_val, hh = h)
+                              quant_val = thres_val, hh = h)
     
  #****************************************************************************************
  #                       LINEARIZED VARIABLE OF THE POVERTY RATE (IN %)                  *


### PR DESCRIPTION
hi, hope all is well with you!  we are reviewing some functions in our `library(convey)` to make sure our mathematics is sound and we're trying to reconcile why some of our at risk of poverty rate calculations are yielding very tiny differences from `library(vardpoor)` ..  we have looked over the calculations in Osier's 2009 paper and we're curious if you might take a look at how `linarpr` implements the equation under section 2.2 on page 182 of the PDF below?  the equation below _By using the derivation rule (33), we obtain_ includes the threshold `x=ARPT (M)` but from our reading of `linarpr`, we're not sure if you're using `x=MED (M)` in this position instead?  we've presented this as a pull request just to make it easier to highlight our question about the implementation but we definitely might be making a mistake or mis-reading the math on our end.  we appreciate your time with this!  -anthony and @guilhermejacob




https://www.researchgate.net/profile/Guillaume-Osier/publication/313562013_Variance_Estimation_for_Complex_Indicators_of_Poverty_and_Inequality_Using_Linearization_Techniques/links/597051ec4585158a48ffa05a/Variance-Estimation-for-Complex-Indicators-of-Poverty-and-Inequality-Using-Linearization-Techniques.pdf#page=17