### PR TITLE
unlist varsYZ for compatibility with upcoming data.table

### DIFF
--- a/vardpoor/R/vardcros.R
+++ b/vardpoor/R/vardcros.R
@@ -625,10 +625,10 @@ vardcros <- function(Y, H, PSU, w_final,
   
   varsYZ <- list(namesY)
   if (!is.null(namesZ)) varsYZ <- list(namesY, namesZ)
+  if (length(varsYZ)==1) varsYZ <- unlist(varsYZ)
   DTagg <- melt(DTagg, id = c(namesperc, gnamesDom),
                 measure = varsYZ,
                 variable.factor = FALSE)
-  
   setnames(DTagg, ifelse(!is.null(DTagg$value1), "value1", "value"), "totalY")
   totYZ <- "totalY"
   if (!is.null(Z)) {totYZ <- c(totYZ, "totalZ")
@@ -731,7 +731,7 @@ vardcros <- function(Y, H, PSU, w_final,
              keyby = namesperc, .SDcols = namesY2]
   varsYZ <- list(namesY1)
   if (!is.null(namesZ1) & !linratio) varsYZ <- list(namesY1, namesZ1)
-  
+  if (length(varsYZ)==1) varsYZ <- unlist(varsYZ)
   DT2 <- melt(DT2, id = namesperc,
               measure = varsYZ,
               variable.factor = FALSE)


### PR DESCRIPTION
Hi @djhurio @JBreidaks 
I see that vardpoor uses data.table::melt, which has slightly different behavior in the next planned release (currently on github only).
Using data.table from github master, we get an error when running vardpoor examples, https://github.com/Rdatatable/data.table/issues/6071
To fix that error, please accept this PR (which should work with both the current version of data.table on CRAN, and on github).
After merging the PR, please submit an update to CRAN.
Thanks!