### PR TITLE
Provide output name directly

### DIFF
--- a/vardpoor/R/vardannual.R
+++ b/vardpoor/R/vardannual.R
@@ -694,9 +694,8 @@ vardannual <- function(Y, H, PSU, w_final, ID_level1,
     X <- cros_rho[["cros_se"]]
     
     annual_var <- data.table(rho2[1, sar, with = FALSE],
-                             (1 - frate / 100) / (subn) ^ 2 *
-                               (t(X) %*% A_matrix) %*% X)
-    setnames(annual_var, c("V1"), c("var"))
+                             var = (1 - frate / 100) / (subn) ^ 2 *
+                                    (t(X) %*% A_matrix) %*% X)
     A_matrix <- data.table(rho2[1, sar, with = FALSE],
                            cols = paste0("V", 1:nrow(A_matrix)), A_matrix)
     list(cros_rho, A_matrix, annual_var)

--- a/vardpoor/R/vardannual.R
+++ b/vardpoor/R/vardannual.R
@@ -694,8 +694,8 @@ vardannual <- function(Y, H, PSU, w_final, ID_level1,
     X <- cros_rho[["cros_se"]]
     
     annual_var <- data.table(rho2[1, sar, with = FALSE],
-                             var = (1 - frate / 100) / (subn) ^ 2 *
-                                    (t(X) %*% A_matrix) %*% X)
+                             var = c((1 - frate / 100) / (subn) ^ 2 *
+                                      (t(X) %*% A_matrix) %*% X))
     A_matrix <- data.table(rho2[1, sar, with = FALSE],
                            cols = paste0("V", 1:nrow(A_matrix)), A_matrix)
     list(cros_rho, A_matrix, annual_var)


### PR DESCRIPTION
In the development version, we made a change for inputs like this that will break this code: autonamed column V1 will become V2; see https://github.com/Rdatatable/data.table/issues/7145.

This change will keep your code back- and forward-compatible.